### PR TITLE
adding support for the line breaks, per the markdown specifications

### DIFF
--- a/src/markdownToDelta.ts
+++ b/src/markdownToDelta.ts
@@ -67,6 +67,10 @@ export default function markdownToDelta(md: string): Op[] {
           insert: node.value,
           attributes: { ...op.attributes, font: "monospace" }
         };
+      } else if (node.type === "break") {
+        op = {
+          insert: "\n"
+        };
       } else {
         throw new Error(`Unsupported note type in paragraph: ${node.type}`);
       }

--- a/test/mixed/07-paragraph-with-breaks.json
+++ b/test/mixed/07-paragraph-with-breaks.json
@@ -1,0 +1,6 @@
+[
+  { "insert": "this is the first line, with two spaces at the end" },
+  { "insert": "\n" },
+  { "insert": "this is the second line" },
+  { "insert": "\n" }
+]

--- a/test/mixed/07-paragraph-with-breaks.md
+++ b/test/mixed/07-paragraph-with-breaks.md
@@ -1,0 +1,2 @@
+this is the first line, with two spaces at the end  
+this is the second line


### PR DESCRIPTION
in markdown, two spaces followed by a carriage return are a line break (cf. https://daringfireball.net/projects/markdown/syntax#p)